### PR TITLE
For ZIP we need a bit of juggling with timestamps

### DIFF
--- a/src/main/java/ca/vanzyl/provisio/archive/zip/ExtendedZipArchiveEntry.java
+++ b/src/main/java/ca/vanzyl/provisio/archive/zip/ExtendedZipArchiveEntry.java
@@ -11,6 +11,9 @@ import ca.vanzyl.provisio.archive.ExtendedArchiveEntry;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Calendar;
+import java.util.Locale;
+import java.util.TimeZone;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 
 public class ExtendedZipArchiveEntry extends ZipArchiveEntry implements ExtendedArchiveEntry {
@@ -65,5 +68,19 @@ public class ExtendedZipArchiveEntry extends ZipArchiveEntry implements Extended
     @Override
     public boolean isExecutable() {
         return false;
+    }
+
+    @Override
+    public void setTime(long timeEpochMillis) {
+        if (timeEpochMillis != -1) {
+            timeEpochMillis = dosToJavaTime(timeEpochMillis, true);
+        }
+        super.setTime(timeEpochMillis);
+    }
+
+    static long dosToJavaTime(long time, boolean adjust) {
+        Calendar cal = Calendar.getInstance(TimeZone.getDefault(), Locale.ROOT);
+        cal.setTimeInMillis(time);
+        return time - ((cal.get(Calendar.ZONE_OFFSET) + (cal.get(Calendar.DST_OFFSET))) * (adjust ? 1 : -1));
     }
 }

--- a/src/main/java/ca/vanzyl/provisio/archive/zip/ExtendedZipArchiveEntry.java
+++ b/src/main/java/ca/vanzyl/provisio/archive/zip/ExtendedZipArchiveEntry.java
@@ -78,9 +78,13 @@ public class ExtendedZipArchiveEntry extends ZipArchiveEntry implements Extended
         super.setTime(timeEpochMillis);
     }
 
-    static long dosToJavaTime(long time, boolean adjust) {
+    /**
+     * Converts DOS epoch to UNIX epoch timestamp and other way around. DOS epoch is "local time" so it is about
+     * removing or adding TZ and DST offset.
+     */
+    static long dosToJavaTime(long time, boolean writeToArchive) {
         Calendar cal = Calendar.getInstance(TimeZone.getDefault(), Locale.ROOT);
         cal.setTimeInMillis(time);
-        return time - ((cal.get(Calendar.ZONE_OFFSET) + (cal.get(Calendar.DST_OFFSET))) * (adjust ? 1 : -1));
+        return time - ((cal.get(Calendar.ZONE_OFFSET) + (cal.get(Calendar.DST_OFFSET))) * (writeToArchive ? 1 : -1));
     }
 }

--- a/src/main/java/ca/vanzyl/provisio/archive/zip/ZipArchiveSource.java
+++ b/src/main/java/ca/vanzyl/provisio/archive/zip/ZipArchiveSource.java
@@ -7,6 +7,8 @@
  */
 package ca.vanzyl.provisio.archive.zip;
 
+import static ca.vanzyl.provisio.archive.zip.ExtendedZipArchiveEntry.dosToJavaTime;
+
 import ca.vanzyl.provisio.archive.ExtendedArchiveEntry;
 import ca.vanzyl.provisio.archive.Source;
 import ca.vanzyl.provisio.archive.perms.FileMode;
@@ -131,14 +133,18 @@ public class ZipArchiveSource implements Source {
 
         @Override
         public long getTime() {
-            return archiveEntry.getTime();
+            long time = archiveEntry.getTime();
+            if (time != -1) {
+                return dosToJavaTime(time, false);
+            }
+            return time;
         }
     }
 
     class ArchiveEntryIterator implements Iterator<ExtendedArchiveEntry> {
 
         @Override
-        public ExtendedArchiveEntry next() {
+        public EntrySourceArchiveEntry next() {
             return new EntrySourceArchiveEntry(entries.nextElement());
         }
 

--- a/src/main/java/ca/vanzyl/provisio/archive/zip/ZipArchiveSource.java
+++ b/src/main/java/ca/vanzyl/provisio/archive/zip/ZipArchiveSource.java
@@ -144,7 +144,7 @@ public class ZipArchiveSource implements Source {
     class ArchiveEntryIterator implements Iterator<ExtendedArchiveEntry> {
 
         @Override
-        public EntrySourceArchiveEntry next() {
+        public ExtendedArchiveEntry next() {
             return new EntrySourceArchiveEntry(entries.nextElement());
         }
 


### PR DESCRIPTION
ZIP timestamp is "local" while Java time is UTC. This makes ZIP archives in fact TZ dependant (where were they built). This PR makes this gone, and normalized ZIPs will have timestamps set irrelevant of TZ where JVM building ZIP runs.

Example to test (in this PR branch):
```
$ git checkout issue-33
$ mvn clean install
[...]
$ unzip -lv target/archives/create-archive-time-0.zip
Archive:  target/archives/create-archive-time-0.zip
 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
--------  ------  ------- ---- ---------- ----- --------  ----
       0  Defl:N        2   0% 01-01-1980 08:00 00000000  archive-time-0/
       0  Defl:N        2   0% 01-01-1980 08:00 00000000  archive-time-0/0/
       1  Defl:N        3 -200% 01-01-1980 08:00 f4dbdf21  archive-time-0/0/0.txt
       0  Defl:N        2   0% 01-01-1980 08:00 00000000  archive-time-0/1/
       1  Defl:N        3 -200% 01-01-1980 08:00 83dcefb7  archive-time-0/1/1.txt
       0  Defl:N        2   0% 01-01-1980 08:00 00000000  archive-time-0/2/
       1  Defl:N        3 -200% 01-01-1980 08:00 1ad5be0d  archive-time-0/2/2.txt
       0  Defl:N        2   0% 01-01-1980 08:00 00000000  archive-time-0/3/
       1  Defl:N        3 -200% 01-01-1980 08:00 6dd28e9b  archive-time-0/3/3.txt
       0  Defl:N        2   0% 01-01-1980 08:00 00000000  archive-time-0/4/
       1  Defl:N        3 -200% 01-01-1980 08:00 f3b61b38  archive-time-0/4/4.txt
       9  Defl:N       11 -22% 01-01-1980 08:00 297b6afc  archive-time-0/4/Foo.class
--------          -------  ---                            -------
      14               38 -171%                            12 files
$ 
$ mvn clean install -Duser.timezone='America/Sao_Paolo'
[...]
$ unzip -lv target/archives/create-archive-time-0.zip
Archive:  target/archives/create-archive-time-0.zip
 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
--------  ------  ------- ---- ---------- ----- --------  ----
       0  Defl:N        2   0% 01-01-1980 08:00 00000000  archive-time-0/
       0  Defl:N        2   0% 01-01-1980 08:00 00000000  archive-time-0/0/
       1  Defl:N        3 -200% 01-01-1980 08:00 f4dbdf21  archive-time-0/0/0.txt
       0  Defl:N        2   0% 01-01-1980 08:00 00000000  archive-time-0/1/
       1  Defl:N        3 -200% 01-01-1980 08:00 83dcefb7  archive-time-0/1/1.txt
       0  Defl:N        2   0% 01-01-1980 08:00 00000000  archive-time-0/2/
       1  Defl:N        3 -200% 01-01-1980 08:00 1ad5be0d  archive-time-0/2/2.txt
       0  Defl:N        2   0% 01-01-1980 08:00 00000000  archive-time-0/3/
       1  Defl:N        3 -200% 01-01-1980 08:00 6dd28e9b  archive-time-0/3/3.txt
       0  Defl:N        2   0% 01-01-1980 08:00 00000000  archive-time-0/4/
       1  Defl:N        3 -200% 01-01-1980 08:00 f3b61b38  archive-time-0/4/4.txt
       9  Defl:N       11 -22% 01-01-1980 08:00 297b6afc  archive-time-0/4/Foo.class
--------          -------  ---                            -------
      14               38 -171%                            12 files
```

Note: the timestamps in case of two Maven builds (w/ different TZ) are _same_. On master on other hand:
```
$ git checkout master
$ mvn clean install
[...]
$ unzip -lv target/archives/create-archive-time-0.zip
Archive:  target/archives/create-archive-time-0.zip
 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
--------  ------  ------- ---- ---------- ----- --------  ----
       0  Defl:N        2   0% 01-01-1980 09:00 00000000  archive-time-0/
       0  Defl:N        2   0% 01-01-1980 09:00 00000000  archive-time-0/0/
       1  Defl:N        3 -200% 01-01-1980 09:00 f4dbdf21  archive-time-0/0/0.txt
       0  Defl:N        2   0% 01-01-1980 09:00 00000000  archive-time-0/1/
       1  Defl:N        3 -200% 01-01-1980 09:00 83dcefb7  archive-time-0/1/1.txt
       0  Defl:N        2   0% 01-01-1980 09:00 00000000  archive-time-0/2/
       1  Defl:N        3 -200% 01-01-1980 09:00 1ad5be0d  archive-time-0/2/2.txt
       0  Defl:N        2   0% 01-01-1980 09:00 00000000  archive-time-0/3/
       1  Defl:N        3 -200% 01-01-1980 09:00 6dd28e9b  archive-time-0/3/3.txt
       0  Defl:N        2   0% 01-01-1980 09:00 00000000  archive-time-0/4/
       1  Defl:N        3 -200% 01-01-1980 09:00 f3b61b38  archive-time-0/4/4.txt
       9  Defl:N       11 -22% 01-01-1980 09:00 297b6afc  archive-time-0/4/Foo.class
--------          -------  ---                            -------
      14               38 -171%                            12 files
$ 
$ mvn clean install -Duser.timezone='America/Sao_Paolo'
[...]
$ unzip -lv target/archives/create-archive-time-0.zip
Archive:  target/archives/create-archive-time-0.zip
 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
--------  ------  ------- ---- ---------- ----- --------  ----
       0  Defl:N        2   0% 01-01-1980 10:00 00000000  archive-time-0/
       0  Defl:N        2   0% 01-01-1980 10:00 00000000  archive-time-0/0/
       1  Defl:N        3 -200% 01-01-1980 10:00 f4dbdf21  archive-time-0/0/0.txt
       0  Defl:N        2   0% 01-01-1980 10:00 00000000  archive-time-0/1/
       1  Defl:N        3 -200% 01-01-1980 10:00 83dcefb7  archive-time-0/1/1.txt
       0  Defl:N        2   0% 01-01-1980 10:00 00000000  archive-time-0/2/
       1  Defl:N        3 -200% 01-01-1980 10:00 1ad5be0d  archive-time-0/2/2.txt
       0  Defl:N        2   0% 01-01-1980 10:00 00000000  archive-time-0/3/
       1  Defl:N        3 -200% 01-01-1980 10:00 6dd28e9b  archive-time-0/3/3.txt
       0  Defl:N        2   0% 01-01-1980 10:00 00000000  archive-time-0/4/
       1  Defl:N        3 -200% 01-01-1980 10:00 f3b61b38  archive-time-0/4/4.txt
       9  Defl:N       11 -22% 01-01-1980 10:00 297b6afc  archive-time-0/4/Foo.class
--------          -------  ---                            -------
      14               38 -171%                            12 files
```

Fixes #33